### PR TITLE
[ApacheFriendsBridge] Add Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ RSS Bridges I've written that are ***not*** included in the [rss-bridge](https:/
 - [Vice](bridges/ViceBridge.php) - Returns the newest posts for a topic from multiple vice.com editions.
 - [The Daily Beast](bridges/TheDailyBeastBridge.php) - Returns newest articles (summary only) by category or keyword.
 - [LGBTQ Nation](bridges/LgbtqNationBridge.php) - Returns newest articles by category, tag or author.
+- [Apache Friends](bridges/ApacheFriendsBridge.php) - Returns newest XAMPP releases.
 
 RSS Bridges I've written or maintain that ***are*** included in the [rss-bridge](https://github.com/RSS-Bridge/rss-bridge) project:
 

--- a/bridges/ApacheFriendsBridge.php
+++ b/bridges/ApacheFriendsBridge.php
@@ -1,0 +1,43 @@
+<?php
+class ApacheFriendsBridge extends FeedExpander {
+
+	const NAME = 'Apache Friends Bridge';
+	const URI = 'https://www.apachefriends.org';
+	const DESCRIPTION = 'Returns newest XAMPP releases';
+	const MAINTAINER = 'VerifiedJoseph';
+
+	const CACHE_TIMEOUT = 3600; // 1 hour
+
+	protected function parseItem($item) {
+
+		// Use published date instead of updated date for the timestamp. 
+		// The updated date value is changed every time a new item is added to the feed, making it useless.
+		$published = $item->published;
+
+		$item = parent::parseItem($item);
+
+		// Fix broken URLs
+		$item['uri'] = str_replace('http://blog.url.com', self::URI, $item['uri']);
+		$item['content'] = defaultLinkTo($item['content'], $this->getURI());
+
+		// Change author from 'Article Author' to 'Apache Friends'.
+		$item['author'] = 'Apache Friends';
+
+		// Set timestamp as published date.
+		$item['timestamp'] = $published;
+
+		return $item;
+	}
+
+	public function collectData() {
+		$this->collectExpandableDatas($this->getURI() . '/feed.xml', 20);
+	}
+
+	public function getName() {
+		return 'Apache Friends';
+	}
+
+	public function getURI() {
+		return self::URI;
+	}
+}


### PR DESCRIPTION
Adds bridge for [Apache friends](https://www.apachefriends.org/index.html). Returns newest XAMPP releases and fixes long standing [broken links](https://community.apachefriends.org/f/viewtopic.php?f=1&t=69839&p=264092&hilit=feed#p264092) issue. Has a 1 hour cache timeout.