### PR TITLE
[ViceBridge] Rename bridge (ViceBridge -> ViceTopicBridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RSS Bridges I've written that are ***not*** included in the [rss-bridge](https:/
 - [HaveIBeenPwnedApi](bridges/HaveIBeenPwnedApiBridge.php) - Returns list of Pwned websites for an email addrees.
 - [TzAnnounceArchive](bridges/TzAnnounceArchiveBridge.php) - Returns Time Zone Database Mailing List.
 - [PhpDotNet](bridges/PhpDotNetBridge.php) - Returns news posts from php.net
-- [Vice](bridges/ViceBridge.php) - Returns the newest posts for a topic from multiple vice.com editions.
+- [Vice.com Topics](bridges/ViceTopicBridge.php) - Returns the newest posts for a topic from multiple vice.com editions.
 - [The Daily Beast](bridges/TheDailyBeastBridge.php) - Returns newest articles (summary only) by category or keyword.
 - [LGBTQ Nation](bridges/LgbtqNationBridge.php) - Returns newest articles by category, tag or author.
 - [Apache Friends](bridges/ApacheFriendsBridge.php) - Returns newest XAMPP releases.

--- a/bridges/ViceTopicBridge.php
+++ b/bridges/ViceTopicBridge.php
@@ -6,7 +6,7 @@
 	The custom cache files are saved in a folder called 'ViceBridgeCache' in the main rss-bridge folder
 	The name and location of the cache folder can be changed by modifying the '$cacheFolder' variable.
 */
-class ViceBridge extends BridgeAbstract {
+class ViceTopicBridge extends BridgeAbstract {
 
 	const NAME = 'Vice.com Topic Bridge';
 	const URI = 'https://vice.com';


### PR DESCRIPTION
Rename bridge `ViceBridge -> ViceTopicBridge` to strop it conflicting with https://github.com/RSS-Bridge/rss-bridge/pull/1310